### PR TITLE
Content shifting upwards on Nextcloud 25.0

### DIFF
--- a/css/cospend.scss
+++ b/css/cospend.scss
@@ -10,6 +10,9 @@ body {
 	// this works but is sketchy
 	// overflow: visible !important;
 	height: auto;
+
+	// Fix content shifting to the top on Nextcloud 25.0.
+	position: relative;
 }
 @media only screen and (max-width: 1024px) {
 	// fix max height being unset in mobile view by server style


### PR DESCRIPTION
This PR fixes an issue in which the content simply shifts to the top and becomes invisible when interacting with the UI. Added a video of the issue.

[cospend-scroll-issue-2022-11-06_14.53.31.webm](https://user-images.githubusercontent.com/21236836/200179200-2750623c-691e-42ae-92d6-b3a80ab41dd2.webm)

Overall the issue seems to be caused most likely by an incompatibility with NextCloud 7.0.0 and above. The main container would grow in height because of its children's content, but as it was not scrollable so it shifted all the content to the top.

Not really sure why the fix actually works, but it does. Attached a document with more information that I gather along the way: [Content shifting upwards.pdf](https://github.com/julien-nc/cospend-nc/files/9946145/Content.shifting.upwards.pdf)