### PR TITLE
Update screenshot URLs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,10 +68,10 @@ Any feedback will be appreciated.
 
 ## Screenshots
 
-![1](https://github.com/eneiluj/cospend-nc/raw/master/img/screenshots/cospend1.jpg)
-![2](https://github.com/eneiluj/cospend-nc/raw/master/img/screenshots/cospend2.jpg)
-![3](https://github.com/eneiluj/cospend-nc/raw/master/img/screenshots/cospend3.jpg)
-![4](https://github.com/eneiluj/cospend-nc/raw/master/img/screenshots/cospend4.jpg)
+![1](https://github.com/julien-nc/cospend-nc/raw/main/img/screenshots/cospend1.jpg)
+![2](https://github.com/julien-nc/cospend-nc/raw/main/img/screenshots/cospend2.jpg)
+![3](https://github.com/julien-nc/cospend-nc/raw/main/img/screenshots/cospend3.jpg)
+![4](https://github.com/julien-nc/cospend-nc/raw/main/img/screenshots/cospend4.jpg)
 
 ## Nightly
 


### PR DESCRIPTION
The branch name and repo URL had both changed (`eneiluj` -> `julien-nc` and `master` -> `main`) which meant screenshots weren't displaying.