### PR TITLE
better error message when importing a Splitwise csv

### DIFF
--- a/lib/Service/ProjectService.php
+++ b/lib/Service/ProjectService.php
@@ -5300,7 +5300,7 @@ class ProjectService {
 					fclose($handle);
 
 					if (!$columnNamesLineFound) {
-						return ['message' => $this->l10n->t('Malformed CSV, impossible to find the column names')];
+						return ['message' => $this->l10n->t('Malformed CSV, impossible to find the column names. Make sure your Splitwise account language is set to English first, then export the project again.')];
 					}
 
 					$memberNameToId = [];


### PR DESCRIPTION
Related to https://github.com/julien-nc/cospend-nc/issues/216

When importing a csv from a non English Splitwise account it errors with `Malformed CSV, impossible to find the column names`

This PR makes the error a bit better by telling the users what to do to get unblocked.

It's my first contribution here, any tips for this PR? Especially on how to do the localization?
It seems there are a lot of places to be updated https://github.com/search?q=repo%3Ajulien-nc%2Fcospend-nc+%22Malformed+CSV%2C+impossible+to+find+the+column+names%22&type=code