### PR TITLE
fix(OpenAPI): Fix duplicate status code definitions

### DIFF
--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -379,7 +379,7 @@ class ApiController extends OCSController {
 	 * @param null $activated
 	 * @param string|null $color
 	 * @param string|null $userId
-	 * @return DataResponse<Http::STATUS_OK, null, array{}>|DataResponse<Http::STATUS_OK, CospendMember, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array<string, string>, array{}>
+	 * @return DataResponse<Http::STATUS_OK, ?CospendMember, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array<string, string>, array{}>
 	 *
 	 * 200: Member was successfully edited (and deleted if it was disabled and wasn't ower of any bill)
 	 * 400: Failed to edit the member
@@ -398,13 +398,11 @@ class ApiController extends OCSController {
 			$activated = false;
 		}
 		$result = $this->projectService->editMember($projectId, $memberId, $name, $userId, $weight, $activated, $color);
-		if (empty($result)) {
-			return new DataResponse(null);
-		} elseif (isset($result['activated'])) {
+		if ($result === null || isset($result['activated'])) {
 			return new DataResponse($result);
-		} else {
-			return new DataResponse($result, Http::STATUS_BAD_REQUEST);
 		}
+
+		return new DataResponse($result, Http::STATUS_BAD_REQUEST);
 	}
 
 	/**

--- a/lib/Controller/OldApiController.php
+++ b/lib/Controller/OldApiController.php
@@ -723,13 +723,11 @@ class OldApiController extends ApiController {
 		$result = $this->projectService->editMember(
 			$publicShareInfo['projectid'], $memberid, $name, $userid, $weight, $activated, $color
 		);
-		if (count($result) === 0) {
-			return new DataResponse(null);
-		} elseif (array_key_exists('activated', $result)) {
+		if ($result === null || isset($result['activated'])) {
 			return new DataResponse($result);
-		} else {
-			return new DataResponse($result, Http::STATUS_FORBIDDEN);
 		}
+
+		return new DataResponse($result, Http::STATUS_FORBIDDEN);
 	}
 
 	#[NoAdminRequired]
@@ -744,13 +742,11 @@ class OldApiController extends ApiController {
 			$activated = false;
 		}
 		$result = $this->projectService->editMember($projectId, $memberid, $name, $userid, $weight, $activated, $color);
-		if (count($result) === 0) {
-			return new DataResponse(null);
-		} elseif (array_key_exists('activated', $result)) {
+		if ($result === null || isset($result['activated'])) {
 			return new DataResponse($result);
-		} else {
-			return new DataResponse($result, Http::STATUS_FORBIDDEN);
 		}
+
+		return new DataResponse($result, Http::STATUS_FORBIDDEN);
 	}
 
 	#[NoAdminRequired]

--- a/lib/Controller/PublicApiController.php
+++ b/lib/Controller/PublicApiController.php
@@ -705,7 +705,7 @@ class PublicApiController extends OCSController {
 	 * @param null $activated
 	 * @param string|null $color
 	 * @param string|null $userId
-	 * @return DataResponse<Http::STATUS_OK, null, array{}>|DataResponse<Http::STATUS_OK, CospendMember, array{}>|DataResponse<Http::STATUS_FORBIDDEN, array<string, string>, array{}>
+	 * @return DataResponse<Http::STATUS_OK, ?CospendMember, array{}>|DataResponse<Http::STATUS_FORBIDDEN, array<string, string>, array{}>
 	 * @throws Exception
 	 */
 	#[NoAdminRequired]
@@ -727,13 +727,11 @@ class PublicApiController extends OCSController {
 		$result = $this->projectService->editMember(
 			$publicShareInfo['projectid'], $memberId, $name, $userId, $weight, $activated, $color
 		);
-		if (count($result) === 0) {
-			return new DataResponse(null);
-		} elseif (isset($result['activated'])) {
+		if ($result === null || isset($result['activated'])) {
 			return new DataResponse($result);
-		} else {
-			return new DataResponse($result, Http::STATUS_FORBIDDEN);
 		}
+
+		return new DataResponse($result, Http::STATUS_FORBIDDEN);
 	}
 
 	/**

--- a/lib/Service/ProjectService.php
+++ b/lib/Service/ProjectService.php
@@ -1269,12 +1269,12 @@ class ProjectService {
 	 * @param float|null $weight
 	 * @param bool $activated
 	 * @param string|null $color
-	 * @return array
+	 * @return array|null
 	 */
 	public function editMember(
 		string $projectId, int $memberId, ?string $name = null, ?string $userId = null,
 		?float $weight = null, ?bool $activated = null, ?string $color = null
-	): array {
+	): array|null {
 		$dbMember = $this->memberMapper->getMemberById($projectId, $memberId);
 		if ($dbMember === null) {
 			return ['name' => $this->l10n->t('This project have no such member')];
@@ -1286,7 +1286,7 @@ class ProjectService {
 			&& count($this->memberMapper->getBillIdsOfMember($memberId)) === 0
 		) {
 			$this->memberMapper->delete($dbMember);
-			return [];
+			return null;
 		}
 
 		if ($name !== null) {

--- a/openapi.json
+++ b/openapi.json
@@ -7640,58 +7640,30 @@
                         "description": "Member was successfully edited (and deleted if it was disabled and wasn't ower of any bill)",
                         "content": {
                             "application/json": {
-                                "schema": [
-                                    {
-                                        "oneOf": [
-                                            {
-                                                "type": "object",
-                                                "required": [
-                                                    "ocs"
-                                                ],
-                                                "properties": {
-                                                    "ocs": {
-                                                        "type": "object",
-                                                        "required": [
-                                                            "meta",
-                                                            "data"
-                                                        ],
-                                                        "properties": {
-                                                            "meta": {
-                                                                "$ref": "#/components/schemas/OCSMeta"
-                                                            },
-                                                            "data": {
-                                                                "nullable": true
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            },
-                                            {
-                                                "type": "object",
-                                                "required": [
-                                                    "ocs"
-                                                ],
-                                                "properties": {
-                                                    "ocs": {
-                                                        "type": "object",
-                                                        "required": [
-                                                            "meta",
-                                                            "data"
-                                                        ],
-                                                        "properties": {
-                                                            "meta": {
-                                                                "$ref": "#/components/schemas/OCSMeta"
-                                                            },
-                                                            "data": {
-                                                                "$ref": "#/components/schemas/Member"
-                                                            }
-                                                        }
-                                                    }
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "$ref": "#/components/schemas/Member",
+                                                    "nullable": true
                                                 }
                                             }
-                                        ]
+                                        }
                                     }
-                                ]
+                                }
                             }
                         }
                     },
@@ -8216,58 +8188,30 @@
                         "description": "",
                         "content": {
                             "application/json": {
-                                "schema": [
-                                    {
-                                        "oneOf": [
-                                            {
-                                                "type": "object",
-                                                "required": [
-                                                    "ocs"
-                                                ],
-                                                "properties": {
-                                                    "ocs": {
-                                                        "type": "object",
-                                                        "required": [
-                                                            "meta",
-                                                            "data"
-                                                        ],
-                                                        "properties": {
-                                                            "meta": {
-                                                                "$ref": "#/components/schemas/OCSMeta"
-                                                            },
-                                                            "data": {
-                                                                "nullable": true
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            },
-                                            {
-                                                "type": "object",
-                                                "required": [
-                                                    "ocs"
-                                                ],
-                                                "properties": {
-                                                    "ocs": {
-                                                        "type": "object",
-                                                        "required": [
-                                                            "meta",
-                                                            "data"
-                                                        ],
-                                                        "properties": {
-                                                            "meta": {
-                                                                "$ref": "#/components/schemas/OCSMeta"
-                                                            },
-                                                            "data": {
-                                                                "$ref": "#/components/schemas/Member"
-                                                            }
-                                                        }
-                                                    }
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "$ref": "#/components/schemas/Member",
+                                                    "nullable": true
                                                 }
                                             }
-                                        ]
+                                        }
                                     }
-                                ]
+                                }
                             }
                         }
                     },


### PR DESCRIPTION
The duplicate definitions of Http::STATUS_OK were causing issues in the spec (yes openapi-extractor should throw errors in these cases; old incomplete pr pending at https://github.com/nextcloud/openapi-extractor/pull/92).
For some reason psalm got really confused here and just doing `?CospendMember` or `CospendMember|null` didn't work so the rest of the code had to be adjusted. I also simplified the handling by returning `null` instead of an empty array if the member was deleted (which I think also helped psalm to understand what is going on).