### PR TITLE
Show total amount owed across projects

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -115,6 +115,7 @@ return [
 		['name' => 'api#autoSettlement', 'url' => '/api/{apiVersion}/projects/{projectId}/auto-settlement', 'verb' => 'GET', 'requirements' => $requirements],
 		['name' => 'api#exportCsvSettlement', 'url' => '/api/{apiVersion}/projects/{projectId}/export-csv-settlement', 'verb' => 'GET', 'requirements' => $requirements],
 		['name' => 'api#getPublicFileShare', 'url' => '/api/{apiVersion}/public-file-share', 'verb' => 'POST', 'requirements' => $requirements],
+		['name' => 'api#getTotalAmountOwed', 'url' => '/api/{apiVersion}/total-amount-owed/{userId}', 'verb' => 'GET', 'requirements' => $requirements],
 		['name' => 'publicApi#publicDeleteProject', 'url' => '/api/{apiVersion}/public/projects/{token}/{password}', 'verb' => 'DELETE', 'requirements' => $requirements],
 		['name' => 'publicApi#publicEditProject', 'url' => '/api/{apiVersion}/public/projects/{token}/{password}', 'verb' => 'PUT', 'requirements' => $requirements],
 		['name' => 'publicApi#publicGetProjectInfo', 'url' => '/api/{apiVersion}/public/projects/{token}/{password}', 'verb' => 'GET', 'requirements' => $requirements],

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -1622,4 +1622,15 @@ class ApiController extends OCSController {
 	public function ping(): DataResponse {
 		return new DataResponse([$this->userId]);
 	}
+
+	#[NoAdminRequired]
+	#[CORS]
+	#[OpenAPI(scope: OpenAPI::SCOPE_DEFAULT, tags: ['Projects'])]
+	public function getTotalAmountOwed(string $userId): DataResponse {
+		if (!$userId) {
+			$userId = $this->userId;
+		}
+		$totalOwed = $this->projectService->getTotalAmountOwedByUser($userId);
+		return new DataResponse(['total_amount_owed' => $totalOwed]);
+	}
 }

--- a/lib/Service/ProjectService.php
+++ b/lib/Service/ProjectService.php
@@ -5096,4 +5096,28 @@ class ProjectService {
 			$qb = $qb->resetQueryParts();
 		}
 	}
+
+	public function getTotalAmountOwedByUser(string $userId): float {
+		$totalOwed = 0;
+		$projects = $this->getProjects($userId);
+
+		
+		foreach ($projects as $project) {
+			if(!is_numeric($userId)){
+				$members = $this->getMembers($project['id'], 'lowername');
+				foreach ($members as $member) {
+					if ($member['userid'] === $userId) {
+						$userId = $member['id'];
+						break;
+					}
+				}
+			}
+			$balances = $this->getBalance($project['id']);
+			if (isset($balances[$userId]) && $balances[$userId] < 0) {
+				$totalOwed += abs($balances[$userId]);
+			}
+		}
+		
+		return $totalOwed;
+	}
 }

--- a/src/network.js
+++ b/src/network.js
@@ -52,6 +52,10 @@ export function exportProject(filename, projectId, projectName) {
 		})
 }
 
+export function getTotalAmountOwed(userId) {
+	const url = generateOcsUrl('/apps/cospend/api/v1/total-amount-owed/{userId}', { userId })
+	return axios.get(url)
+}
 export function getProjects() {
 	const url = cospend.pageIsPublic
 		? generateOcsUrl('/apps/cospend/api/v1/public/projects/{projectId}/{password}', { projectId: cospend.projectid, password: cospend.password })


### PR DESCRIPTION
Fixes #281 at least for nextcloud accounts. i didn't touched the translations, as i am not sure how.

**Motivation**: From my side i have multiple projects with my partner(who also has a nextcloud account) and she always like to see how much she is owing me in total, not per project.

_For the future to also show amounts owed by non-nextcloud accounts:_
The idea could be that if you click on the Total Amount Owed navigation item, that you will then see a total breakdown of all members against each other and the total amount owed for each person. However i am not sure if this is so easily feasible, because a project is shared alone and other projects are not visible. But maybe the api can just calculate this for all projects nevertheless, based on the name of the persons (meaning if different persons have the same name across projects, an admin would need to rename it in one project to fix this case for the calculation)