### PR TITLE
Improve Cross-OS Development

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
 		"test": "tests"
 	},
 	"scripts": {
-		"dev": "NODE_ENV=development webpack --progress --config webpack.js",
-		"watch": "NODE_ENV=development webpack --progress --watch --config webpack.js",
-		"build": "NODE_ENV=production webpack --progress --config webpack.js",
-		"serve": "NODE_ENV=development webpack serve --progress --config webpack.js",
+		"dev": "webpack --node-env development --progress",
+		"watch": "webpack --progress --node-env development --watch",
+		"build": "webpack --node-env production --progress",
+		"serve": "webpack serve --node-env development --progress",
 		"lint": "eslint --ext .js,.vue src",
 		"lint:fix": "eslint --ext .js,.vue src --fix",
 		"stylelint": "stylelint src/**/*.vue src/**/*.scss src/**/*.css",


### PR DESCRIPTION
i am on windows and the environment variables setting syntax does not work like this in the package.json - there are ways around this. my favorite is pnpm and a option to automatically convert them. however i wanted to have this plain and easy and thus used the webpack parameter, which works across all OSes.

I also removed the webpack config path, because it is by default the one that was set, feel free to adapt it, if there was a reason for this.

I also need to include the following packages locally for my machine, not sure if they should be included, so i omited it from this PR:
```
"babel-loader": "^9.1.3",
"webpack": "^5.92.1",
"webpack-cli": "^5.1.4"
```