### PR TITLE
Don't use uppercase letters in project share token

### DIFF
--- a/lib/Service/LocalProjectService.php
+++ b/lib/Service/LocalProjectService.php
@@ -2969,6 +2969,18 @@ class LocalProjectService implements IProjectService {
 	}
 
 	/**
+	 * Generate a random share token for a project
+	 *
+	 * @return string
+	 */
+	private function generateShareToken() {
+		return $this->secureRandom->generate(
+			FederationManager::TOKEN_LENGTH,
+			ISecureRandom::CHAR_LOWER . ISecureRandom::CHAR_DIGITS
+		);
+	}
+
+	/**
 	 * Add a federated shared access to a project
 	 *
 	 * @param string $projectId
@@ -3000,11 +3012,7 @@ class LocalProjectService implements IProjectService {
 			);
 		}
 
-		$shareToken = $this->secureRandom->generate(
-			FederationManager::TOKEN_LENGTH,
-			ISecureRandom::CHAR_HUMAN_READABLE
-		);
-
+		$shareToken = $this->generateShareToken();
 		$newShare = new Share();
 		$newShare->setProjectId($projectId);
 		$newShare->setUserId($shareToken);
@@ -3153,10 +3161,7 @@ class LocalProjectService implements IProjectService {
 	public function createPublicShare(
 		string $projectId, ?string $label = null, ?string $password = null, int $accesslevel = Application::ACCESS_LEVEL_PARTICIPANT,
 	): array {
-		$shareToken = $this->secureRandom->generate(
-			FederationManager::TOKEN_LENGTH,
-			ISecureRandom::CHAR_HUMAN_READABLE
-		);
+		$shareToken = $this->generateShareToken();
 		$share = new Share();
 		$share->setProjectId($projectId);
 		$share->setUserId($shareToken);


### PR DESCRIPTION
To remain compatible with PayForMe, which requires lowercase project share tokens, only use lowercase chars and digits in project shares.

Fixes #327
See also mayflower/PayForMe#68