### PR TITLE
Add migration to fix missing users in members

### DIFF
--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -62,9 +62,6 @@ jobs:
       - name: Install dependencies
         run: composer require --dev nextcloud/ocp:${{ matrix.ocp-version }} --ignore-platform-reqs --with-dependencies
 
-      - name: Install dependencies
-        run: composer require --dev
-
       - name: Run coding standards check
         run: composer run psalm
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -3,7 +3,7 @@
 	<id>cospend</id>
 	<name>Cospend</name>
 	<summary> </summary><description> </description>
-	<version>3.0.11</version>
+	<version>3.0.12</version>
 	<licence>agpl</licence>
 	<author mail="julien-nc@posteo.net">Julien Veyssier</author>
 	<namespace>Cospend</namespace>
@@ -27,6 +27,11 @@
 		<job>OCA\Cospend\Cron\RepeatBills</job>
 		<job>OCA\Cospend\Cron\AutoExport</job>
 	</background-jobs>
+    <repair-steps>
+        <post-migration>
+            <step>OCA\Cospend\Migration\CleanupUserMembers</step>
+        </post-migration>
+    </repair-steps>
 	<settings>
 		<admin>OCA\Cospend\Settings\Admin</admin>
 	</settings>

--- a/lib/Migration/CleanupUserMembers.php
+++ b/lib/Migration/CleanupUserMembers.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace OCA\Cospend\Migration;
+
+use OCA\Cospend\Db\MemberMapper;
+use OCP\DB\Exception;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+
+class CleanupUserMembers implements IRepairStep {
+
+	public function __construct(
+		private MemberMapper $memberMapper,
+	) {
+	}
+
+	public function getName() {
+		return 'Fix Cospend project members whose related NC user does not exist';
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @throws Exception
+	 */
+	public function run(IOutput $output) {
+		$fixedUserIds = $this->memberMapper->cleanupUserMembers();
+		if (empty($fixedUserIds)) {
+			$output->info('No members to fix');
+		} else {
+			$output->info('Fixed ' . count($fixedUserIds) . ' Cospend project members whose related NC user does not exist:');
+			$output->info(implode(', ', $fixedUserIds));
+		}
+	}
+}

--- a/lib/Service/LocalProjectService.php
+++ b/lib/Service/LocalProjectService.php
@@ -46,6 +46,7 @@ use OCP\AppFramework\Db\MultipleObjectsReturnedException;
 use OCP\AppFramework\Http;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 
+use OCP\Exceptions\AppConfigTypeConflictException;
 use OCP\Federation\ICloudIdManager;
 
 use OCP\IAppConfig;
@@ -325,6 +326,7 @@ class LocalProjectService implements IProjectService {
 	 * @throws DoesNotExistException
 	 * @throws MultipleObjectsReturnedException
 	 * @throws \OCP\DB\Exception
+	 * @throws AppConfigTypeConflictException
 	 */
 	public function getProjectInfo(string $projectId): array {
 		try {


### PR DESCRIPTION
This is an addition to #338.

It fixes the existing members for which the related user does not exist.

Also systematically apply this fix when getting a project info in case of a weird db state (yes people manually touch the db).
@provokateurin What do you think about the performance impact of running this cleanup each time the project info is loaded? This is much safer but adds a one or two DB queries per project info loading and potentially a bunch of `IUserManager::get()``.