### PR TITLE
provider: placeholder user id must be a string

### DIFF
--- a/lib/Activity/CospendProvider.php
+++ b/lib/Activity/CospendProvider.php
@@ -90,7 +90,7 @@ class CospendProvider implements IProvider {
 			$params = [
 				'user' => [
 					'type' => 'user',
-					'id' => 0,
+					'id' => '0',
 					'name' => $subjectParams['author']
 				],
 			];


### PR DESCRIPTION
Nextcloud 31 enforces runtime type checks: https://github.com/nextcloud/server/pull/47662.
Error localized by: https://github.com/nextcloud/activity/issues/1967#issuecomment-2783840156.
Closes https://github.com/julien-nc/cospend-nc/issues/342.
