### PR TITLE
test: add federation integration tests (Behat, two-instance)

### DIFF
--- a/.github/workflows/integration-federation.yml
+++ b/.github/workflows/integration-federation.yml
@@ -1,0 +1,89 @@
+name: Federation integration tests
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/integration-federation.yml'
+      - 'appinfo/**'
+      - 'lib/**'
+      - 'tests/integration/**'
+      - 'composer.json'
+      - 'composer.lock'
+  push:
+    branches:
+      - main
+      - master
+      - stable*
+
+permissions:
+  contents: read
+
+env:
+  APP_NAME: cospend
+
+jobs:
+  federation:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php-versions: ['8.3']
+        server-versions: ['master']
+
+    name: php${{ matrix.php-versions }}-${{ matrix.server-versions }}
+
+    steps:
+      - name: Checkout server
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+          repository: nextcloud/server
+          ref: ${{ matrix.server-versions }}
+          submodules: true
+
+      - name: Checkout app
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+          path: apps/${{ env.APP_NAME }}
+
+      - name: Set up php ${{ matrix.php-versions }}
+        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # v2.36.0
+        with:
+          php-version: ${{ matrix.php-versions }}
+          extensions: mbstring, iconv, fileinfo, intl, sqlite, pdo_sqlite, apcu, gd, curl
+          ini-values: apc.enable_cli=on
+          coverage: none
+
+      - name: Set up app dependencies
+        working-directory: apps/${{ env.APP_NAME }}
+        run: composer install --no-dev --no-interaction
+
+      - name: Install Nextcloud
+        run: |
+          mkdir data
+          php occ maintenance:install \
+            --verbose \
+            --database=sqlite \
+            --database-name=nextcloud \
+            --admin-user=admin \
+            --admin-pass=admin
+          php occ config:system:set hashing_default_password --value=true --type=boolean
+          php occ config:system:set memcache.local --value="\\OC\\Memcache\\APCu"
+          php occ app:enable --force ${{ env.APP_NAME }}
+
+      - name: Run federation integration tests
+        working-directory: apps/${{ env.APP_NAME }}/tests/integration
+        run: bash run-federation.sh
+
+      - name: Print Nextcloud log on failure
+        if: always()
+        run: |
+          if [ -f data/nextcloud.log ]; then
+            cat data/nextcloud.log
+          fi
+          if [ -f data/tests-cospend-federated-server/data/nextcloud.log ]; then
+            echo "--- REMOTE LOG ---"
+            cat data/tests-cospend-federated-server/data/nextcloud.log
+          fi

--- a/tests/integration/.gitignore
+++ b/tests/integration/.gitignore
@@ -1,0 +1,2 @@
+composer.lock
+vendor/

--- a/tests/integration/composer.json
+++ b/tests/integration/composer.json
@@ -2,6 +2,7 @@
     "require-dev": {
         "behat/behat": "~3.26.0",
         "guzzlehttp/guzzle": "7.9.2",
+        "phpunit/phpunit": "~10",
         "jarnaiz/behat-junit-formatter": "^1.3",
         "symfony/event-dispatcher": "~5.4"
     },

--- a/tests/integration/composer.json
+++ b/tests/integration/composer.json
@@ -1,0 +1,15 @@
+{
+    "require-dev": {
+        "behat/behat": "~3.26.0",
+        "guzzlehttp/guzzle": "7.9.2",
+        "jarnaiz/behat-junit-formatter": "^1.3",
+        "symfony/event-dispatcher": "~5.4"
+    },
+    "autoload": {
+        "psr-0": {
+            "": [
+                "features/bootstrap/"
+            ]
+        }
+    }
+}

--- a/tests/integration/config/behat.yml
+++ b/tests/integration/config/behat.yml
@@ -1,0 +1,11 @@
+default:
+  formatters:
+    pretty:
+      output_styles:
+        comment: [ 'bright-blue' ]
+  suites:
+    federation:
+      paths:
+        - '%paths.base%/../features/federation/'
+      contexts:
+        - FederationContext

--- a/tests/integration/features/bootstrap/FederationContext.php
+++ b/tests/integration/features/bootstrap/FederationContext.php
@@ -1,0 +1,324 @@
+<?php
+
+declare(strict_types=1);
+
+use Behat\Behat\Context\Context;
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ClientException;
+use PHPUnit\Framework\Assert;
+use Psr\Http\Message\ResponseInterface;
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+/**
+ * Federation integration test context for Cospend.
+ *
+ * Uses OCS API with Basic Auth exclusively (no cookie-based auth) to avoid
+ * session issues with PHP's built-in web server across two instances.
+ */
+class FederationContext implements Context {
+	private string $localServerUrl;
+	private string $remoteServerUrl;
+	private string $currentServer = 'LOCAL';
+
+	private string $localRootDir;
+	private string $remoteRootDir;
+	private string $remoteConfigDir;
+
+	private string $currentUser = 'admin';
+	private ?ResponseInterface $response = null;
+
+	/** @var array|null Last project created on LOCAL */
+	private ?array $project = null;
+	/** @var int|null Invitation ID received on REMOTE */
+	private ?int $pendingInvitationId = null;
+
+	/** @BeforeScenario */
+	public function gatherContexts(BeforeScenarioScope $scope): void {
+		$this->localServerUrl = rtrim(getenv('TEST_SERVER_URL') ?: 'http://localhost:8080/', '/');
+		$this->remoteServerUrl = rtrim(getenv('TEST_REMOTE_URL') ?: 'http://localhost:8280/', '/');
+		$this->localRootDir = getenv('NEXTCLOUD_HOST_ROOT_DIR') ?: '';
+		$this->remoteRootDir = getenv('NEXTCLOUD_REMOTE_ROOT_DIR') ?: '';
+		$this->remoteConfigDir = getenv('NEXTCLOUD_REMOTE_CONFIG_DIR') ?: '';
+	}
+
+	// ---- Helpers ----
+
+	private function getServerUrl(?string $server = null): string {
+		$server = $server ?? $this->currentServer;
+		return $server === 'REMOTE' ? $this->remoteServerUrl : $this->localServerUrl;
+	}
+
+	private function getRootDir(?string $server = null): string {
+		$server = $server ?? $this->currentServer;
+		return $server === 'REMOTE' ? $this->remoteRootDir : $this->localRootDir;
+	}
+
+	private function getOccEnvPrefix(?string $server = null): string {
+		$server = $server ?? $this->currentServer;
+		if ($server === 'REMOTE' && !empty($this->remoteConfigDir)) {
+			return 'NEXTCLOUD_CONFIG_DIR=' . escapeshellarg($this->remoteConfigDir) . ' ';
+		}
+		return '';
+	}
+
+	private function getPassword(string $user): string {
+		return ($user === 'admin') ? 'admin' : '123456';
+	}
+
+	private function occ(string $server, string $command): void {
+		$rootDir = $this->getRootDir($server);
+		$envPrefix = $this->getOccEnvPrefix($server);
+		exec("{$envPrefix}php {$rootDir}/occ {$command} 2>&1", $output, $returnCode);
+		if ($returnCode !== 0) {
+			throw new \RuntimeException("occ {$command} failed on {$server}: " . implode("\n", $output));
+		}
+	}
+
+	/**
+	 * Send an OCS request with Basic Auth to the given (or current) server.
+	 */
+	private function sendOCSRequest(
+		string $method,
+		string $path,
+		array $data = [],
+		?string $user = null,
+		?string $server = null,
+	): ResponseInterface {
+		$user = $user ?? $this->currentUser;
+		$baseUrl = $this->getServerUrl($server);
+		$url = $baseUrl . '/ocs/v2.php/' . ltrim($path, '/');
+
+		$client = new Client(['http_errors' => false]);
+		$options = [
+			'auth' => [$user, $this->getPassword($user)],
+			'headers' => [
+				'OCS-APIREQUEST' => 'true',
+				'Accept' => 'application/json',
+			],
+		];
+		if (!empty($data)) {
+			$options['json'] = $data;
+		}
+
+		$this->response = $client->request($method, $url, $options);
+		return $this->response;
+	}
+
+	private function getOCSResponseCode(): int {
+		$this->response->getBody()->seek(0);
+		$json = json_decode((string)$this->response->getBody(), true);
+		return (int)($json['ocs']['meta']['statuscode'] ?? $this->response->getStatusCode());
+	}
+
+	private function getOCSData(): array {
+		$this->response->getBody()->seek(0);
+		$json = json_decode((string)$this->response->getBody(), true);
+		return $json['ocs']['data'] ?? [];
+	}
+
+	// ---- Step definitions ----
+
+	/**
+	 * @Given /^using server "([^"]*)"$/
+	 */
+	public function usingServer(string $server): void {
+		$this->currentServer = strtoupper($server);
+	}
+
+	/**
+	 * @Given /^acting as "([^"]*)"$/
+	 */
+	public function actingAs(string $user): void {
+		$this->currentUser = $user;
+	}
+
+	/**
+	 * @Given /^federation is enabled on "([^"]*)"$/
+	 */
+	public function federationIsEnabledOn(string $server): void {
+		$this->occ($server, 'config:app:set cospend federation_enabled --value=1');
+		$this->occ($server, 'config:app:set cospend federation_incoming_enabled --value=1');
+		$this->occ($server, 'config:app:set cospend federation_outgoing_enabled --value=1');
+		$this->occ($server, 'config:app:set files_sharing outgoing_server2server_share_enabled --value=yes');
+		$this->occ($server, 'config:app:set files_sharing incoming_server2server_share_enabled --value=yes');
+	}
+
+	/**
+	 * @Given /^user "([^"]*)" exists on "([^"]*)"$/
+	 */
+	public function userExistsOn(string $user, string $server): void {
+		$password = $this->getPassword($user);
+		$rootDir = $this->getRootDir($server);
+		$envPrefix = $this->getOccEnvPrefix($server);
+		exec("{$envPrefix}OC_PASS={$password} php {$rootDir}/occ user:add --password-from-env {$user} 2>&1", $output, $returnCode);
+		if ($returnCode !== 0) {
+			// User already exists — reset password to ensure it matches
+			exec("{$envPrefix}OC_PASS={$password} php {$rootDir}/occ user:resetpassword --password-from-env {$user} 2>&1");
+		}
+	}
+
+	/**
+	 * @Given /^"([^"]*)" creates a project "([^"]*)" on "([^"]*)"$/
+	 */
+	public function userCreatesProject(string $user, string $name, string $server): void {
+		$this->sendOCSRequest('POST', 'apps/cospend/api/v1/projects', [
+			'name' => $name,
+			'id' => strtolower(str_replace(' ', '-', $name)),
+		], $user, $server);
+		Assert::assertEquals(200, $this->getOCSResponseCode(), 'Failed to create project: ' . $this->response->getBody());
+		$this->project = $this->getOCSData();
+		Assert::assertArrayHasKey('id', $this->project, 'Project creation did not return an id');
+	}
+
+	/**
+	 * @When /^"([^"]*)" on "([^"]*)" shares project with federated user "([^"]*)"$/
+	 */
+	public function userSharesProjectWithFederatedUser(string $user, string $server, string $remoteUser): void {
+		Assert::assertNotNull($this->project, 'No project created yet');
+		$remoteServerUrl = ($server === 'LOCAL') ? $this->remoteServerUrl : $this->localServerUrl;
+		$userCloudId = $remoteUser . '@' . $remoteServerUrl;
+
+		$this->sendOCSRequest('POST', 'apps/cospend/api/v1/projects/' . $this->project['id'] . '/federated-share', [
+			'userCloudId' => $userCloudId,
+		], $user, $server);
+	}
+
+	/**
+	 * @Then /^the OCS status code should be "([^"]*)"$/
+	 */
+	public function theOCSStatusCodeShouldBe(string $code): void {
+		Assert::assertEquals((int)$code, $this->getOCSResponseCode(),
+			'Unexpected OCS status code. Body: ' . $this->response->getBody());
+	}
+
+	/**
+	 * @Then /^"([^"]*)" on "([^"]*)" has (\d+) pending invitation[s]?$/
+	 */
+	public function userHasPendingInvitations(string $user, string $server, int $expected): void {
+		// OCM shares may take a moment to propagate — retry a few times
+		$invitations = [];
+		for ($i = 0; $i < 10; $i++) {
+			$this->sendOCSRequest('GET', 'apps/cospend/api/v1/federation/pending-invitations', [], $user, $server);
+			$invitations = $this->getOCSData();
+			if (count($invitations) >= $expected) {
+				break;
+			}
+			usleep(500000); // 500ms
+		}
+		Assert::assertCount($expected, $invitations, "Expected {$expected} pending invitations but got " . count($invitations));
+		if ($expected > 0) {
+			$this->pendingInvitationId = (int)$invitations[0]['id'];
+		}
+	}
+
+	/**
+	 * @When /^"([^"]*)" on "([^"]*)" accepts the pending invitation$/
+	 */
+	public function userAcceptsPendingInvitation(string $user, string $server): void {
+		Assert::assertNotNull($this->pendingInvitationId, 'No pending invitation found in previous step');
+		$this->sendOCSRequest('POST', 'apps/cospend/api/v1/federation/invitation/' . $this->pendingInvitationId, [], $user, $server);
+		Assert::assertEquals(200, $this->getOCSResponseCode(), 'Failed to accept invitation: ' . $this->response->getBody());
+	}
+
+	/**
+	 * @When /^"([^"]*)" on "([^"]*)" rejects the pending invitation$/
+	 */
+	public function userRejectsPendingInvitation(string $user, string $server): void {
+		Assert::assertNotNull($this->pendingInvitationId, 'No pending invitation found in previous step');
+		$this->sendOCSRequest('DELETE', 'apps/cospend/api/v1/federation/invitation/' . $this->pendingInvitationId, [], $user, $server);
+		Assert::assertEquals(200, $this->getOCSResponseCode(), 'Failed to reject invitation: ' . $this->response->getBody());
+	}
+
+	/**
+	 * @Then /^"([^"]*)" on "([^"]*)" can see the federated project "([^"]*)"$/
+	 */
+	public function userCanSeeFederatedProject(string $user, string $server, string $projectName): void {
+		// After accepting, the federated project list should reflect it — retry for propagation
+		$found = false;
+		for ($i = 0; $i < 10; $i++) {
+			$this->sendOCSRequest('GET', 'apps/cospend/api/v1/federated-projects', [], $user, $server);
+			$projects = $this->getOCSData();
+			foreach ($projects as $project) {
+				if ($project['remoteProjectName'] === $projectName) {
+					$found = true;
+					break 2;
+				}
+			}
+			usleep(500000);
+		}
+		Assert::assertTrue($found, "Federated project '{$projectName}' not found for {$user} on {$server}");
+	}
+
+	/**
+	 * @Then /^"([^"]*)" on "([^"]*)" cannot see any federated projects$/
+	 */
+	public function userCannotSeeAnyFederatedProjects(string $user, string $server): void {
+		$this->sendOCSRequest('GET', 'apps/cospend/api/v1/federated-projects', [], $user, $server);
+		$projects = $this->getOCSData();
+		Assert::assertCount(0, $projects, 'Expected no federated projects but found: ' . count($projects));
+	}
+
+	/**
+	 * @Then /^"([^"]*)" on "([^"]*)" has (\d+) federated share[s]? on the project$/
+	 */
+	public function projectHasFederatedShares(string $user, string $server, int $expected): void {
+		Assert::assertNotNull($this->project, 'No project created yet');
+		$this->sendOCSRequest('GET', 'apps/cospend/api/v1/projects/' . $this->project['id'] . '/info', [], $user, $server);
+		$data = $this->getOCSData();
+		$federatedShares = array_filter($data['shares'] ?? [], fn($s) => $s['type'] === 'f');
+		Assert::assertCount($expected, $federatedShares, "Expected {$expected} federated shares but found " . count($federatedShares));
+	}
+
+	/**
+	 * @When /^"([^"]*)" on "([^"]*)" removes the federated share$/
+	 */
+	public function userRemovesFederatedShare(string $user, string $server): void {
+		Assert::assertNotNull($this->project, 'No project created yet');
+		$this->sendOCSRequest('GET', 'apps/cospend/api/v1/projects/' . $this->project['id'] . '/info', [], $user, $server);
+		$data = $this->getOCSData();
+		$federatedShare = null;
+		foreach ($data['shares'] ?? [] as $share) {
+			if ($share['type'] === 'f') {
+				$federatedShare = $share;
+				break;
+			}
+		}
+		Assert::assertNotNull($federatedShare, 'No federated share found on project');
+
+		$this->sendOCSRequest('DELETE', 'apps/cospend/api/v1/projects/' . $this->project['id'] . '/federated-share/' . $federatedShare['id'], [], $user, $server);
+		Assert::assertEquals(200, $this->getOCSResponseCode(), 'Failed to remove federated share: ' . $this->response->getBody());
+	}
+
+	/**
+	 * @Given /^outgoing federation is disabled on "([^"]*)"$/
+	 */
+	public function outgoingFederationIsDisabledOn(string $server): void {
+		$this->occ($server, 'config:app:set cospend federation_outgoing_enabled --value=0');
+	}
+
+	/**
+	 * @Given /^incoming federation is disabled on "([^"]*)"$/
+	 */
+	public function incomingFederationIsDisabledOn(string $server): void {
+		$this->occ($server, 'config:app:set cospend federation_incoming_enabled --value=0');
+	}
+
+	/**
+	 * @Then /^"([^"]*)" on "([^"]*)" has (\d+) pending invitation[s]? after waiting$/
+	 */
+	public function userHasPendingInvitationsAfterWaiting(string $user, string $server, int $expected): void {
+		// Allow time for OCM unshare notification to arrive
+		$invitations = [];
+		for ($i = 0; $i < 10; $i++) {
+			$this->sendOCSRequest('GET', 'apps/cospend/api/v1/federation/pending-invitations', [], $user, $server);
+			$invitations = $this->getOCSData();
+			if (count($invitations) === $expected) {
+				break;
+			}
+			usleep(500000);
+		}
+		Assert::assertCount($expected, $invitations, "Expected {$expected} pending invitations but found " . count($invitations));
+	}
+}

--- a/tests/integration/features/federation/settings.feature
+++ b/tests/integration/features/federation/settings.feature
@@ -1,0 +1,27 @@
+@federation
+Feature: Federation settings enforcement
+  Admin settings for incoming and outgoing federation are respected
+
+  Background:
+    Given using server "LOCAL"
+    And federation is enabled on "LOCAL"
+    And user "admin" exists on "LOCAL"
+    Given using server "REMOTE"
+    And federation is enabled on "REMOTE"
+    And user "admin" exists on "REMOTE"
+
+  Scenario: Outgoing federation disabled prevents sharing
+    Given using server "LOCAL"
+    And "admin" creates a project "Blocked Outgoing" on "LOCAL"
+    And outgoing federation is disabled on "LOCAL"
+    When "admin" on "LOCAL" shares project with federated user "admin"
+    Then the OCS status code should be "400"
+    And "admin" on "LOCAL" has 0 federated shares on the project
+
+  Scenario: Incoming federation disabled rejects OCM share
+    Given using server "LOCAL"
+    And "admin" creates a project "Blocked Incoming" on "LOCAL"
+    And incoming federation is disabled on "REMOTE"
+    When "admin" on "LOCAL" shares project with federated user "admin"
+    Then the OCS status code should be "400"
+    And "admin" on "REMOTE" has 0 pending invitations

--- a/tests/integration/features/federation/sharing.feature
+++ b/tests/integration/features/federation/sharing.feature
@@ -1,0 +1,42 @@
+@federation
+Feature: Federation project sharing
+  Share Cospend projects across federated Nextcloud instances
+
+  Background:
+    Given using server "LOCAL"
+    And federation is enabled on "LOCAL"
+    And user "admin" exists on "LOCAL"
+    Given using server "REMOTE"
+    And federation is enabled on "REMOTE"
+    And user "admin" exists on "REMOTE"
+
+  Scenario: Share a project with a user on a remote server
+    Given using server "LOCAL"
+    And "admin" creates a project "Shared Project" on "LOCAL"
+    When "admin" on "LOCAL" shares project with federated user "admin"
+    Then the OCS status code should be "200"
+    And "admin" on "LOCAL" has 1 federated shares on the project
+
+  Scenario: Remote user receives a pending invitation
+    Given using server "LOCAL"
+    And "admin" creates a project "Invite Project" on "LOCAL"
+    When "admin" on "LOCAL" shares project with federated user "admin"
+    Then the OCS status code should be "200"
+    And "admin" on "REMOTE" has 1 pending invitation
+
+  Scenario: Remote user accepts a pending invitation
+    Given using server "LOCAL"
+    And "admin" creates a project "Accepted Project" on "LOCAL"
+    When "admin" on "LOCAL" shares project with federated user "admin"
+    Then "admin" on "REMOTE" has 1 pending invitation
+    When "admin" on "REMOTE" accepts the pending invitation
+    Then "admin" on "REMOTE" can see the federated project "Accepted Project"
+
+  Scenario: Remote user rejects a pending invitation
+    Given using server "LOCAL"
+    And "admin" creates a project "Rejected Project" on "LOCAL"
+    When "admin" on "LOCAL" shares project with federated user "admin"
+    Then "admin" on "REMOTE" has 1 pending invitation
+    When "admin" on "REMOTE" rejects the pending invitation
+    Then "admin" on "REMOTE" cannot see any federated projects
+    And "admin" on "REMOTE" has 0 pending invitations

--- a/tests/integration/features/federation/unshare.feature
+++ b/tests/integration/features/federation/unshare.feature
@@ -1,0 +1,31 @@
+@federation
+Feature: Federation project unsharing
+  Remove federated project shares and verify cleanup on both sides
+
+  Background:
+    Given using server "LOCAL"
+    And federation is enabled on "LOCAL"
+    And user "admin" exists on "LOCAL"
+    Given using server "REMOTE"
+    And federation is enabled on "REMOTE"
+    And user "admin" exists on "REMOTE"
+
+  Scenario: Host removes a federated share and remote user loses access
+    Given using server "LOCAL"
+    And "admin" creates a project "Shared For Removal" on "LOCAL"
+    When "admin" on "LOCAL" shares project with federated user "admin"
+    Then "admin" on "REMOTE" has 1 pending invitation
+    When "admin" on "REMOTE" accepts the pending invitation
+    Then "admin" on "REMOTE" can see the federated project "Shared For Removal"
+    When "admin" on "LOCAL" removes the federated share
+    Then "admin" on "LOCAL" has 0 federated shares on the project
+    And "admin" on "REMOTE" has 0 pending invitations after waiting
+
+  Scenario: Host removes a share that was never accepted
+    Given using server "LOCAL"
+    And "admin" creates a project "Pending Only" on "LOCAL"
+    When "admin" on "LOCAL" shares project with federated user "admin"
+    Then "admin" on "LOCAL" has 1 federated shares on the project
+    And "admin" on "REMOTE" has 1 pending invitation
+    When "admin" on "LOCAL" removes the federated share
+    Then "admin" on "LOCAL" has 0 federated shares on the project

--- a/tests/integration/router.php
+++ b/tests/integration/router.php
@@ -32,4 +32,7 @@ foreach ($parts as $part) {
 }
 
 // Virtual paths (/.well-known/ocm, /ocm-provider, etc.) -> index.php
+// Set SCRIPT_NAME so Nextcloud's getRawPathInfo() can compute the path correctly
+$_SERVER['SCRIPT_NAME'] = '/index.php';
+$_SERVER['SCRIPT_FILENAME'] = $docRoot . '/index.php';
 include $docRoot . '/index.php';

--- a/tests/integration/router.php
+++ b/tests/integration/router.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * PHP built-in web server router for Nextcloud integration tests.
+ *
+ * Routes virtual paths like /.well-known/ocm and /ocm-provider through
+ * index.php, while letting the built-in server handle real files and
+ * PHP scripts (including PATH_INFO paths like /ocs/v2.php/apps/...).
+ *
+ * Usage:
+ *   php -S localhost:8080 -t /path/to/nextcloud /path/to/router.php
+ */
+
+declare(strict_types=1);
+
+$path = urldecode(parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH) ?? '/');
+$docRoot = $_SERVER['DOCUMENT_ROOT'];
+
+// Serve existing files directly
+if (is_file($docRoot . $path)) {
+	return false;
+}
+
+// Walk up the path to find a .php script — handles PATH_INFO paths
+// e.g. /ocs/v2.php/apps/cospend/api/v1/projects -> found ocs/v2.php
+$parts = explode('/', ltrim($path, '/'));
+$candidate = '';
+foreach ($parts as $part) {
+	$candidate .= '/' . $part;
+	if (is_file($docRoot . $candidate) && str_ends_with($candidate, '.php')) {
+		return false; // PHP built-in server handles it with PATH_INFO
+	}
+}
+
+// Virtual paths (/.well-known/ocm, /ocm-provider, etc.) -> index.php
+include $docRoot . '/index.php';

--- a/tests/integration/run-federation.sh
+++ b/tests/integration/run-federation.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+
+# Federation integration test runner for Cospend
+# Sets up two Nextcloud instances (LOCAL + REMOTE) and runs Behat federation tests.
+#
+# Usage:
+#   ./run-federation.sh [behat-scenario-or-feature-path]
+#
+# Environment:
+#   REMOTE_ROOT_DIR  (optional) Path to an existing second Nextcloud installation.
+#                   If unset, a fresh instance is created under data/.
+
+set -e
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+OCC="${ROOT_DIR}/occ"
+APP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCENARIO_TO_RUN=$1
+
+LOCAL_PORT=8080
+REMOTE_PORT=8280
+
+# ---- Verify the main instance is installed ----
+
+INSTALLED=$(php "$OCC" status | grep installed: | cut -d " " -f 5)
+if [ "$INSTALLED" != "true" ]; then
+	echo "Nextcloud instance needs to be installed first" >&2
+	exit 1
+fi
+
+# ---- Set up the remote Nextcloud instance ----
+
+if [ -z "$REMOTE_ROOT_DIR" ]; then
+	REMOTE_ROOT_DIR="${ROOT_DIR}/data/tests-cospend-federated-server"
+
+	echo "Setting up local federated Nextcloud instance at ${REMOTE_ROOT_DIR}"
+
+	rm -rf "${REMOTE_ROOT_DIR}"
+	mkdir -p "${REMOTE_ROOT_DIR}"
+
+	# Symlink all server files except data/ and config/ so we share source code
+	for item in "${ROOT_DIR}"/*; do
+		name=$(basename "$item")
+		if [ "$name" != "data" ] && [ "$name" != "config" ]; then
+			ln -sf "$item" "${REMOTE_ROOT_DIR}/${name}"
+		fi
+	done
+
+	mkdir -p "${REMOTE_ROOT_DIR}/data"
+	mkdir -p "${REMOTE_ROOT_DIR}/config"
+
+	REMOTE_OCC="NEXTCLOUD_CONFIG_DIR=${REMOTE_ROOT_DIR}/config php ${REMOTE_ROOT_DIR}/occ"
+
+	eval $REMOTE_OCC maintenance:install \
+		--database=sqlite \
+		--admin-user=admin \
+		--admin-pass=admin \
+		--data-dir="${REMOTE_ROOT_DIR}/data"
+
+	eval $REMOTE_OCC config:system:set hashing_default_password --value=true --type=boolean
+	eval $REMOTE_OCC app:enable --force cospend
+else
+	echo "Using external remote Nextcloud instance at ${REMOTE_ROOT_DIR}"
+	REMOTE_OCC="NEXTCLOUD_CONFIG_DIR=${REMOTE_ROOT_DIR}/config php ${REMOTE_ROOT_DIR}/occ"
+fi
+
+MAIN_SERVER_CONFIG_DIR="${ROOT_DIR}/config"
+REMOTE_SERVER_CONFIG_DIR="${REMOTE_ROOT_DIR}/config"
+
+# ---- Install Behat dependencies ----
+
+# Server-level Behat vendor (provides shared step definitions)
+(
+	cd "${ROOT_DIR}/vendor-bin/behat"
+	composer install --no-interaction
+)
+
+# App-level integration test dependencies
+(
+	cd "${APP_DIR}/tests/integration"
+	composer install --no-interaction
+)
+
+# ---- Configure LOCAL instance ----
+
+php "$OCC" app:enable --force cospend
+
+php "$OCC" config:system:set allow_local_remote_servers --value=true --type=boolean
+php "$OCC" config:system:set auth.bruteforce.protection.enabled --value=false --type=boolean
+php "$OCC" config:system:set ratelimit.protection.enabled --value=false --type=boolean
+php "$OCC" config:system:set debug --value=true --type=boolean
+php "$OCC" config:system:set hashing_default_password --value=true --type=boolean
+php "$OCC" config:app:set cospend federation_enabled --value=1
+php "$OCC" config:app:set cospend federation_incoming_enabled --value=1
+php "$OCC" config:app:set cospend federation_outgoing_enabled --value=1
+php "$OCC" config:app:set files_sharing outgoing_server2server_share_enabled --value=yes
+php "$OCC" config:app:set files_sharing incoming_server2server_share_enabled --value=yes
+php "$OCC" config:system:set trusted_domains 0 --value="localhost:${LOCAL_PORT}"
+
+# ---- Configure REMOTE instance ----
+
+eval $REMOTE_OCC config:system:set allow_local_remote_servers --value=true --type=boolean
+eval $REMOTE_OCC config:system:set auth.bruteforce.protection.enabled --value=false --type=boolean
+eval $REMOTE_OCC config:system:set ratelimit.protection.enabled --value=false --type=boolean
+eval $REMOTE_OCC config:system:set debug --value=true --type=boolean
+eval $REMOTE_OCC config:app:set cospend federation_enabled --value=1
+eval $REMOTE_OCC config:app:set cospend federation_incoming_enabled --value=1
+eval $REMOTE_OCC config:app:set cospend federation_outgoing_enabled --value=1
+eval $REMOTE_OCC config:app:set files_sharing outgoing_server2server_share_enabled --value=yes
+eval $REMOTE_OCC config:app:set files_sharing incoming_server2server_share_enabled --value=yes
+eval $REMOTE_OCC config:system:set trusted_domains 0 --value="localhost:${REMOTE_PORT}"
+
+# ---- Start PHP built-in servers ----
+
+echo "Starting LOCAL server on localhost:${LOCAL_PORT}"
+PHP_CLI_SERVER_WORKERS=3 php -S "localhost:${LOCAL_PORT}" -t "${ROOT_DIR}" &
+LOCAL_PID=$!
+
+echo "Starting REMOTE server on localhost:${REMOTE_PORT}"
+NEXTCLOUD_CONFIG_DIR="${REMOTE_ROOT_DIR}/config" PHP_CLI_SERVER_WORKERS=3 php -S "localhost:${REMOTE_PORT}" -t "${ROOT_DIR}" &
+REMOTE_PID=$!
+
+sleep 2
+
+if ! curl -sf "http://localhost:${LOCAL_PORT}/status.php" > /dev/null; then
+	echo "LOCAL server failed to start" >&2
+	kill -9 $LOCAL_PID $REMOTE_PID 2>/dev/null
+	exit 1
+fi
+
+if ! curl -sf "http://localhost:${REMOTE_PORT}/status.php" > /dev/null; then
+	echo "REMOTE server failed to start" >&2
+	kill -9 $LOCAL_PID $REMOTE_PID 2>/dev/null
+	exit 1
+fi
+
+echo "Both servers are running"
+
+# ---- Export environment variables for Behat ----
+
+export TEST_SERVER_URL="http://localhost:${LOCAL_PORT}/"
+export TEST_REMOTE_URL="http://localhost:${REMOTE_PORT}/"
+export NEXTCLOUD_HOST_ROOT_DIR="${ROOT_DIR}"
+export NEXTCLOUD_HOST_CONFIG_DIR="${MAIN_SERVER_CONFIG_DIR}"
+export NEXTCLOUD_REMOTE_ROOT_DIR="${REMOTE_ROOT_DIR}"
+export NEXTCLOUD_REMOTE_CONFIG_DIR="${REMOTE_SERVER_CONFIG_DIR}"
+
+# ---- Run Behat federation tests ----
+
+cd "${APP_DIR}/tests/integration"
+
+if [ -n "$SCENARIO_TO_RUN" ]; then
+	vendor/bin/behat --config config/behat.yml --colors --suite=federation "$SCENARIO_TO_RUN"
+else
+	vendor/bin/behat --config config/behat.yml --colors --suite=federation
+fi
+RESULT=$?
+
+# ---- Cleanup ----
+
+kill -9 $LOCAL_PID $REMOTE_PID 2>/dev/null
+
+echo "Federation tests finished with exit code: $RESULT"
+exit $RESULT

--- a/tests/integration/run-federation.sh
+++ b/tests/integration/run-federation.sh
@@ -96,6 +96,7 @@ php "$OCC" config:app:set cospend federation_outgoing_enabled --value=1
 php "$OCC" config:app:set files_sharing outgoing_server2server_share_enabled --value=yes
 php "$OCC" config:app:set files_sharing incoming_server2server_share_enabled --value=yes
 php "$OCC" config:system:set trusted_domains 0 --value="localhost:${LOCAL_PORT}"
+php "$OCC" config:system:set overwrite.cli.url --value="http://localhost:${LOCAL_PORT}/"
 
 # ---- Configure REMOTE instance ----
 
@@ -109,15 +110,18 @@ eval $REMOTE_OCC config:app:set cospend federation_outgoing_enabled --value=1
 eval $REMOTE_OCC config:app:set files_sharing outgoing_server2server_share_enabled --value=yes
 eval $REMOTE_OCC config:app:set files_sharing incoming_server2server_share_enabled --value=yes
 eval $REMOTE_OCC config:system:set trusted_domains 0 --value="localhost:${REMOTE_PORT}"
+eval $REMOTE_OCC config:system:set overwrite.cli.url --value="http://localhost:${REMOTE_PORT}/"
 
 # ---- Start PHP built-in servers ----
 
+ROUTER_SCRIPT="${APP_DIR}/tests/integration/router.php"
+
 echo "Starting LOCAL server on localhost:${LOCAL_PORT}"
-PHP_CLI_SERVER_WORKERS=3 php -S "localhost:${LOCAL_PORT}" -t "${ROOT_DIR}" &
+PHP_CLI_SERVER_WORKERS=3 php -S "localhost:${LOCAL_PORT}" -t "${ROOT_DIR}" "${ROUTER_SCRIPT}" &
 LOCAL_PID=$!
 
 echo "Starting REMOTE server on localhost:${REMOTE_PORT}"
-NEXTCLOUD_CONFIG_DIR="${REMOTE_ROOT_DIR}/config" PHP_CLI_SERVER_WORKERS=3 php -S "localhost:${REMOTE_PORT}" -t "${ROOT_DIR}" &
+NEXTCLOUD_CONFIG_DIR="${REMOTE_ROOT_DIR}/config" PHP_CLI_SERVER_WORKERS=3 php -S "localhost:${REMOTE_PORT}" -t "${ROOT_DIR}" "${ROUTER_SCRIPT}" &
 REMOTE_PID=$!
 
 sleep 2


### PR DESCRIPTION
Sets up the same two-PHP-server pattern used by Deck (PR #7734) and Spreed:
- run-federation.sh: creates a second NC instance under data/, configures both, starts two PHP built-in servers on :8080/:8280, runs Behat, then tears down
- FederationContext.php: OCS/Basic-Auth context with steps for server switching, user creation via occ, project creation, federated share/accept/reject/remove, pending-invitation polling with retry, and settings toggle helpers
- sharing.feature: send invite → pending invite appears → accept → project visible; also tests rejection path
- unshare.feature: host removes accepted share → remote loses access; host removes pending (never-accepted) share
- settings.feature: outgoing disabled blocks share creation (400); incoming disabled on remote causes OCM share to be refused (400)
- integration-federation.yml: GitHub Actions workflow (PHP 8.3, NC master, SQLite) mirroring the Deck federation CI workflow

- [x] This PR was partly or wholly created by AI