### PR TITLE
Update duplicated bills to use current timestamp

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -802,6 +802,8 @@ export default {
 						this.currentBill = {
 							...bill,
 							id: 0,
+							// Use today's date for duplicated bills
+							timestamp: moment().unix(),
 						}
 					} else {
 						const payerId = this.defaultPayerId
@@ -839,6 +841,8 @@ export default {
 						Object.assign(this.currentBill, {
 							...bill,
 							id: 0,
+							// Use today's date for duplicated bills
+							timestamp: moment().unix(),
 						})
 					}
 				}


### PR DESCRIPTION
#345 was annoying me as well so I decided to try and add this feature. 

I'm not a programmer - I asked Claude to study the code and tell me what I'd need to implement this and it suggested the changes here.

I tested this version out in the browser and things seem to work fine. I'll also merge these changes into my [cross-project branch](https://github.com/AkshayRao27/cospend-nc/tree/cross-project-balances-and-settlement) to check if they play nicely with the changes I have on that one.