### PR TITLE
fix: derive the legacy payment_mode char from the right project

### DIFF
--- a/lib/Service/LocalProjectService.php
+++ b/lib/Service/LocalProjectService.php
@@ -65,6 +65,9 @@ class LocalProjectService implements IProjectService {
 	public array $defaultPaymentModes;
 	private array $hardCodedCategoryNames;
 	private ?array $paymentModes = null;
+	// which project $paymentModes was loaded for; without it a request touching more than one
+	// project keeps the first project's modes and the legacy 'payment_mode' char falls back to 'n'
+	private ?string $paymentModesProjectId = null;
 
 	public function __construct(
 		private IL10N $l10n,
@@ -927,9 +930,10 @@ class LocalProjectService implements IProjectService {
 		?int $timestamp = null, ?string $comment = null, ?int $repeatFreq = null,
 		int $deleted = 0, bool $produceActivity = false,
 	): int {
-		// if we don't have the payment modes, get them now
-		if ($this->paymentModes === null) {
+		// if we don't have this project's payment modes, get them now
+		if ($this->paymentModes === null || $this->paymentModesProjectId !== $projectId) {
 			$this->paymentModes = $this->getCategoriesOrPaymentModes($projectId, false);
+			$this->paymentModesProjectId = $projectId;
 		}
 
 		if ($repeat === null || $repeat === '' || strlen($repeat) !== 1) {
@@ -2154,9 +2158,10 @@ class LocalProjectService implements IProjectService {
 		?int $timestamp = null, ?string $comment = null, ?int $repeatFreq = null,
 		?int $deleted = null, bool $produceActivity = false,
 	): void {
-		// if we don't have the payment modes, get them now
-		if ($this->paymentModes === null) {
+		// if we don't have this project's payment modes, get them now
+		if ($this->paymentModes === null || $this->paymentModesProjectId !== $projectId) {
 			$this->paymentModes = $this->getCategoriesOrPaymentModes($projectId, false);
+			$this->paymentModesProjectId = $projectId;
 		}
 
 		$dbBill = $this->billMapper->getBillEntity($projectId, $billId);


### PR DESCRIPTION
Opus 5 found this when I was having it work on a feature I wanted:

### The problem

`LocalProjectService::$paymentModes` is loaded once per service instance and is not keyed by project:

```php
private ?array $paymentModes = null;
...
if ($this->paymentModes === null) {
    $this->paymentModes = $this->getCategoriesOrPaymentModes($projectId, false);
}
```

In a request that creates or edits bills in more than one project, the second project reuses the
first project's payment modes. The lookup just below it then fails to find the payment mode and the
legacy `payment_mode` char silently falls back to `'n'`:

```php
$paymentMode = 'n';
if (isset($this->paymentModes[$paymentModeId]['old_id']) && ...) {
    $paymentMode = $this->paymentModes[$paymentModeId]['old_id'];
}
```

The result is a bill whose `payment_mode_id` is correct but whose `payment_mode` is wrong. Classic
mode filtering and CSV export read the legacy column, so such bills silently disappear from both
while looking perfectly fine in the bill list and in the API.

### Reproducing it

The payment mode cache is written in exactly two places — inside `createBill()` and `editBill()` —
so reaching this needs two bill writes, in different projects, within one request.

`cronRepeatBills()` is that path, and it runs unattended. `lib/Cron/RepeatBills.php` calls it with
no `$billId`, so it walks **every** repeating bill on the instance through a single service
instance, and `repeatLocalBill()` calls `createBill($projectId, …)` for each. The first project's
modes populate the cache; every later project's payment mode id is then absent from it.

The derivation also *overwrites* a correct value rather than leaving it alone. `repeatLocalBill()`
passes both `$bill['paymentmode']` and `$bill['paymentmodeid']`, and because `$paymentModeId` is
non-null the block sets `$paymentMode = 'n'` before consulting the cache — so the caller's correct
legacy char is discarded on a miss.

Net effect on any instance with repeating bills in two or more projects: every night, all but the
first-processed project produces bills that look correct in the UI and in the API, and are invisible
to classic-mode filtering and CSV export.

### The fix

Remember which project the cache was loaded for and reload when it changes. Both call sites
(`createBill`, `editBill`) are updated identically.